### PR TITLE
Feat/command registration

### DIFF
--- a/src/main/java/net/paradise_client/ParadiseClient.java
+++ b/src/main/java/net/paradise_client/ParadiseClient.java
@@ -15,7 +15,7 @@ import net.minecraft.util.Identifier;
 import net.paradise_client.addon.AddonLoader;
 import net.paradise_client.command.CommandManager;
 import net.paradise_client.discord.RPC;
-import net.paradise_client.exploit.ExploitManager;
+import net.paradise_client.exploit.ExploitRegistry;
 import net.paradise_client.mod.*;
 import net.paradise_client.packet.*;
 import org.lwjgl.glfw.GLFW;
@@ -52,7 +52,7 @@ public class ParadiseClient implements ModInitializer, ClientModInitializer {
     public static ChatRoomMod CHAT_ROOM_MOD;
     public static ExploitMod EXPLOIT_MOD;
     public static CommandManager COMMAND_MANAGER;
-    public static ExploitManager EXPLOIT_MANAGER;
+    public static ExploitRegistry EXPLOIT_REGISTRY;
     public static NetworkMod NETWORK_MOD;
     public static RPC RPC;
 
@@ -99,8 +99,8 @@ public class ParadiseClient implements ModInitializer, ClientModInitializer {
     }
 
     private void initializeManagers() {
-        EXPLOIT_MANAGER = new ExploitManager(MINECRAFT_CLIENT);
-        EXPLOIT_MANAGER.init();
+        EXPLOIT_REGISTRY = new ExploitRegistry(MINECRAFT_CLIENT);
+        EXPLOIT_REGISTRY.init();
 
         COMMAND_MANAGER = new CommandManager(MINECRAFT_CLIENT);
         COMMAND_MANAGER.init();

--- a/src/main/java/net/paradise_client/command/impl/ExploitCommand.java
+++ b/src/main/java/net/paradise_client/command/impl/ExploitCommand.java
@@ -27,9 +27,9 @@ public class ExploitCommand extends Command {
     @Override
     public void build(LiteralArgumentBuilder<CommandSource> root) {
         // Add subcommands for each exploit
-        ParadiseClient.EXPLOIT_MANAGER.getExploits().forEach(exploit -> root.then(literal(exploit.getAlias())
+        ParadiseClient.EXPLOIT_REGISTRY.getExploits().forEach(exploit -> root.then(literal(exploit.getAlias())
                 .executes((context) -> {
-                    ParadiseClient.EXPLOIT_MANAGER.handleExploit(exploit.getAlias());
+                    ParadiseClient.EXPLOIT_REGISTRY.handleExploit(exploit.getAlias());
                     return SINGLE_SUCCESS;
                 })));
 

--- a/src/main/java/net/paradise_client/exploit/ExploitInitializationException.java
+++ b/src/main/java/net/paradise_client/exploit/ExploitInitializationException.java
@@ -1,0 +1,25 @@
+package net.paradise_client.exploit;
+
+/**
+ * Custom exception for exploit initialization failures.
+ */
+public class ExploitInitializationException extends RuntimeException {
+    /**
+     * Constructs a new ExploitInitializationException with the specified message.
+     *
+     * @param message The detail message.
+     */
+    public ExploitInitializationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new ExploitInitializationException with the specified message and cause.
+     *
+     * @param message The detail message.
+     * @param cause   The cause of the exception.
+     */
+    public ExploitInitializationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/net/paradise_client/exploit/ExploitRegistry.java
+++ b/src/main/java/net/paradise_client/exploit/ExploitRegistry.java
@@ -14,7 +14,7 @@ import java.util.List;
  * @author SpigotRCE
  * @since 2.5
  */
-public class ExploitManager {
+public class ExploitRegistry {
     private final MinecraftClient minecraftClient;
 
     /**
@@ -25,7 +25,7 @@ public class ExploitManager {
     /**
      * Constructs a new ExploitManager with the given exploits.
      */
-    public ExploitManager(MinecraftClient minecraftClient) {
+    public ExploitRegistry(MinecraftClient minecraftClient) {
         this.minecraftClient = minecraftClient;
     }
 

--- a/src/main/java/net/paradise_client/exploit/ExploitRegistry.java
+++ b/src/main/java/net/paradise_client/exploit/ExploitRegistry.java
@@ -1,13 +1,16 @@
 package net.paradise_client.exploit;
 
+import com.google.common.reflect.ClassPath;
 import net.minecraft.client.MinecraftClient;
+import net.paradise_client.Constants;
 import net.paradise_client.Helper;
 import net.paradise_client.ParadiseClient;
-import net.paradise_client.exploit.impl.*;
 
-import java.util.ArrayList;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Manages and handles various exploits.
@@ -17,27 +20,57 @@ import java.util.List;
  */
 public class ExploitRegistry {
     private final MinecraftClient minecraftClient;
+    private final List<Exploit> exploits;
 
     /**
-     * A list of all available exploits.
-     */
-    private final ArrayList<Exploit> exploits = new ArrayList<>();
-
-    /**
-     * Constructs a new ExploitManager with the given exploits.
+     * Constructs a new ExploitRegistry with the given Minecraft client.
+     *
+     * @param minecraftClient The Minecraft client instance, must not be null.
+     * @throws IllegalArgumentException if minecraftClient is null.
      */
     public ExploitRegistry(MinecraftClient minecraftClient) {
+        if (minecraftClient == null) {
+            throw new IllegalArgumentException("MinecraftClient cannot be null");
+        }
         this.minecraftClient = minecraftClient;
+        this.exploits = new CopyOnWriteArrayList<>();
     }
 
-    public void init() {
-        register(new BrigadierExploit(minecraftClient));
-        register(new PaperWindowExploit(minecraftClient));
-        register(new SignExploit(minecraftClient));
-        register(new NegativeInfinityExploit(minecraftClient));
-        register(new VelocityReportExploit(minecraftClient));
-        register(new ViaVersionExploit(minecraftClient));
+    /**
+     * Initializes the exploit registry by scanning and registering exploits from the specified package.
+     *
+     * @throws ExploitInitializationException if an error occurs during class scanning or exploit instantiation.
+     */
+    public void init() throws ExploitInitializationException {
+        try {
+            ClassLoader classLoader = getClass().getClassLoader();
+            ClassPath classPath = ClassPath.from(classLoader);
+            Class<?> minecraftClientClass = minecraftClient.getClass();
+
+            List<ClassPath.ClassInfo> classes = classPath
+                    .getTopLevelClassesRecursive("net.paradise_client.exploit.impl")
+                    .stream().toList();
+
+            for (ClassPath.ClassInfo classInfo : classes) {
+                try {
+                    Class<?> clazz = Class.forName(classInfo.getName(), true, classLoader);
+                    if (Exploit.class.isAssignableFrom(clazz) && !clazz.isInterface() && !java.lang.reflect.Modifier.isAbstract(clazz.getModifiers())) {
+                        Constructor<?> constructor = clazz.getConstructor(minecraftClientClass);
+                        Exploit exploit = (Exploit) constructor.newInstance(minecraftClient);
+                        register(exploit);
+                    }
+                } catch (NoSuchMethodException e) {
+                    Constants.LOGGER.error("No suitable constructor for {} with MinecraftClient parameter", classInfo.getName(), e);
+                } catch (Exception e) {
+                    Constants.LOGGER.error("Failed to instantiate exploit: {}", classInfo.getName(), e);
+                }
+            }
+            Constants.LOGGER.info("Registered {} exploits", exploits.size());
+        } catch (IOException e) {
+            throw new ExploitInitializationException("Failed to scan classes for exploits", e);
+        }
     }
+
 
     /**
      * Executes the exploit with the specified alias.

--- a/src/main/java/net/paradise_client/exploit/ExploitRegistry.java
+++ b/src/main/java/net/paradise_client/exploit/ExploitRegistry.java
@@ -6,6 +6,7 @@ import net.paradise_client.ParadiseClient;
 import net.paradise_client.exploit.impl.*;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -39,14 +40,18 @@ public class ExploitRegistry {
     }
 
     /**
-     * Handles the execution of the exploit with the given name.
+     * Executes the exploit with the specified alias.
      *
-     * @param name The name of the exploit to be executed.
+     * @param alias The alias of the exploit to execute.
+     * @throws IllegalArgumentException if the alias is null or empty.
      */
-    public void handleExploit(String name) {
-        Exploit exploit = getExploit(name);
+    public void handleExploit(String alias) {
+        if (alias == null || alias.trim().isEmpty()) {
+            throw new IllegalArgumentException("Exploit alias cannot be null or empty");
+        }
+        Exploit exploit = getExploit(alias);
         if (exploit == null) {
-            Helper.printChatMessage("Unknown exploit.");
+            Helper.printChatMessage("Unknown exploit: " + alias);
             return;
         }
         ParadiseClient.EXPLOIT_MOD.isRunning = true;
@@ -54,33 +59,42 @@ public class ExploitRegistry {
     }
 
     /**
-     * Retrieves the exploit with the given alias.
+     * Retrieves the exploit with the specified alias (case-insensitive).
      *
-     * @param alias The alias of the exploit to be retrieved.
-     * @return The exploit with the given alias, or null if no such exploit exists.
+     * @param alias The alias of the exploit to retrieve.
+     * @return The exploit with the given alias, or null if not found.
      */
     public Exploit getExploit(String alias) {
-        for (Exploit exploit : exploits)
-            if (exploit.getAlias().equals(alias))
+        if (alias == null) {
+            return null;
+        }
+        for (Exploit exploit : exploits) {
+            if (alias.equalsIgnoreCase(exploit.getAlias())) {
                 return exploit;
+            }
+        }
         return null;
     }
 
     /**
-     * Retrieves the exploit with the given alias.
+     * Registers a new exploit.
      *
-     * @param exploit The {@link Exploit} to be registered.
+     * @param exploit The exploit to register, must not be null.
+     * @throws IllegalArgumentException if the exploit is null.
      */
     public void register(Exploit exploit) {
-        this.exploits.add(exploit);
+        if (exploit == null) {
+            throw new IllegalArgumentException("Exploit cannot be null");
+        }
+        exploits.add(exploit);
     }
 
     /**
-     * Retrieves the list of all available exploits.
+     * Retrieves an unmodifiable list of all registered exploits.
      *
-     * @return The list of all available exploits.
+     * @return An unmodifiable list of all registered exploits.
      */
     public List<Exploit> getExploits() {
-        return exploits;
+        return Collections.unmodifiableList(exploits);
     }
 }


### PR DESCRIPTION
This pull request refactors the exploit management system in the Paradise Client by replacing the `ExploitManager` class with a new `ExploitRegistry` class. It also introduces a custom exception for exploit initialization errors. Below is a summary of the most important changes:

### Refactoring exploit management:

* Renamed `ExploitManager` to `ExploitRegistry` in `ParadiseClient` 
* Added the `ExploitRegistry` class, which automates exploit discovery using reflection to scan for exploit implementations in a specified package. This simplifies initialization and makes the system more extensible

### Error handling improvements:

* Introduced a new `ExploitInitializationException` class to handle errors during exploit initialization, such as class scanning or instantiation failures. (`[src/main/java/net/paradise_client/exploit/ExploitInitializationException.javaR1-R25](diffhunk://#diff-54089127fc001dc114b4c784862f8571fb15c9964ca50673de86df44d2b5be9fR1-R25)`)